### PR TITLE
Remove docs on YKD_PRINT_IR=jit-pre-opt-sbs.

### DIFF
--- a/src/dev/env.md
+++ b/src/dev/env.md
@@ -14,7 +14,5 @@ The following stages are supported:
 
  - `aot`: the IR embedded in the ahead-of-time compiled binary.
  - `jit-pre-opt`: the IR for the trace before it is optimised by LLVM.
- - `jit-pre-opt-sbs`: the IR for the trace before it is optimised alongside the
-   AOT IR from which it was derived. Inlining boundaries are also annotated.
  - `jit-post-opt`: the IR for the trace after LLVM has optimised it. This is
    the IR that will be submitted to the LLVM code generator.


### PR DESCRIPTION
This mode has been removed from yk.